### PR TITLE
signup-form support for email autocomplete

### DIFF
--- a/apps/signup-form/src/components/pages/FormView.tsx
+++ b/apps/signup-form/src/components/pages/FormView.tsx
@@ -65,7 +65,8 @@ const Form: React.FC<FormProps> = ({isMinimal, loading, success, error, buttonCo
                     data-testid="input"
                     disabled={loading || success}
                     placeholder={t('Your email address')}
-                    type="text"
+                    type="email"
+                    autocomplete="email"
                     value={email}
                     onChange={e => setEmail(e.target.value)}
                 />


### PR DESCRIPTION
<!-- Got some code for us? Awesome 🎊! Please fill in this template and check your PR against the below todos, thanks! -->

## Description

Updates [embeddable signup forms](https://ghost.org/help/embeddable-signup-forms/) to use `type="email"` and `autocomplete="email"`. This has several benefits:

- The user's browser has better support for autofilling their email to save typing (enabled by `autocomplete="email"`)
- Mobile keyboards helpfully switch to email layout (making `@` immediately available for example)
- ♿️ passing [1.3.5 Identify Input Purpose](https://www.w3.org/TR/WCAG22/#identify-input-purpose)

| Before | After |
| --- | --- |
| ![IMG_1781](https://github.com/AssistivLabs/ghost-demo/assets/709153/3579002b-886f-4a33-aedf-d3bef3ab55a9) | ![IMG_1782](https://github.com/AssistivLabs/ghost-demo/assets/709153/fda70d50-1ea2-4da2-9590-cf5dc76b90af) |

## Related issues

<!-- If you write "Closes" followed by the Github issue number, it will automatically close the issue for you when the PR merges -->

N/A

## Testing steps

<!-- If changes are not covered by `yarn test:all`, describe how you tested them -->

Tested against iOS Safari manually. Our jest suite is ill suited since this is a test of browser integration.

### Testing accessibility

<!-- If this is a UI change or could otherwise effect accessibility, please run the below tests -->

- [x] [NVDA spot check instructions](https://ghost.com/docs/accessibility/nvda) - no changes in announcement
- [x] [Windows High Contrast Mode spot check instructions](https://ghost.com/docs/accessibility/whcm) - no changes in display
